### PR TITLE
Remove command prefixes

### DIFF
--- a/authorization-code/README.md
+++ b/authorization-code/README.md
@@ -55,8 +55,8 @@ The authorization code workflow is described in
 1. Install dependencies in both provider and client directories:
 
 ```shell
-$ cd provider && npm install
-$ cd ../client && npm install
+cd provider && npm install
+cd ../client && npm install
 ```
 
 2. Create a `.env` file in the authorization-code/provider directory:
@@ -82,13 +82,13 @@ REDIRECT_URI=http://localhost:3000/callback
 4. Start the provider (authorization server + resource server):
 
 ```shell
-$ cd provider && npm start
+cd provider && npm start
 ```
 
 5. Start the client application:
 
 ```shell
-$ cd client && npm start
+cd client && npm start
 ```
 
 6. Visit http://localhost:3000 to start the authorization code flow.

--- a/databases/memory/Readme.md
+++ b/databases/memory/Readme.md
@@ -24,7 +24,7 @@ node index.js
 2. Open a new terminal and get a token from the `/token` endpoint
 
 ```shell
-$ curl -d "grant_type=password&username=jdoe&password=foobarbaz"  -u "doeclient:foobarbaz" "http://localhost:3000/token"
+curl -d "grant_type=password&username=jdoe&password=foobarbaz"  -u "doeclient:foobarbaz" "http://localhost:3000/token"
 ```
 
 It should return a json response, something like this
@@ -41,7 +41,7 @@ It should return a json response, something like this
 3. access the `/secret` route with the token
 
 ```shell
-$ curl -i -H "Authorization: Bearer abe2eb52cf61d62b28ac503befc1b49405858f265aee0daf0e0f51faf656b03d" http://localhost:3000/secret
+curl -i -H "Authorization: Bearer abe2eb52cf61d62b28ac503befc1b49405858f265aee0daf0e0f51faf656b03d" http://localhost:3000/secret
 ```
 
 It should return a response like this

--- a/server2server/README.md
+++ b/server2server/README.md
@@ -47,8 +47,8 @@ Therefore, the setup looks something like this:
 If you haven't already cloned this repository, then clone it via
 
 ```shell
-$ git clone https://github.com/node-oauth/node-oauth2-server-examples.git
-$ cd server2server
+git clone https://github.com/node-oauth/node-oauth2-server-examples.git
+cd server2server
 ```
 
 ### Install and run the provider
@@ -57,9 +57,9 @@ Since we have two servers you need to install dependencies in both.
 First, start with the provider:
 
 ```shell
-$ cd provider
-$ npm install
-$ npm run start
+cd provider
+npm install
+npm run start
 ```
 
 The provider runs on `http://localhost:8080`
@@ -68,9 +68,9 @@ The provider runs on `http://localhost:8080`
 ### Install and run the consumer
 
 ```shell
-$ cd ../consumer
-$ npm install
-$ npm run start
+cd ../consumer
+npm install
+npm run start
 ```
 
 The consumer will now make several requests. Note, that some of them are expected to fail.


### PR DESCRIPTION
This would make it easier to use via GitHub "copy to clipboard".